### PR TITLE
chore: Migrate gsutil usage to gcloud storage

### DIFF
--- a/src/features/device_management/commands/check_image/suggest_image.ts
+++ b/src/features/device_management/commands/check_image/suggest_image.ts
@@ -176,7 +176,7 @@ async function showAllMatchingImagesQuickPick(
           Array.from({length: maxSkew}, (_, k) => chromeosMajorVersion - k - 1)
         );
         let finishedCount = 0;
-        // Since `listPrebuiltVersions` has to be called separately for each version (`gsutil ls`
+        // Since `listPrebuiltVersions` has to be called separately for each version (`gcloud storage ls`
         // does not take regex for pattern matching, only wildcard), update the list using event
         // emitter instead of waiting for all calls to finish.
         const onFetchedImageVersionsEmitter = new vscode.EventEmitter<

--- a/src/features/device_management/prebuilt_util.ts
+++ b/src/features/device_management/prebuilt_util.ts
@@ -37,8 +37,9 @@ export async function listPrebuiltVersions(
   // gs://chromeos-image-archive/ contains prebuilt image files.
   // https://chromium.googlesource.com/chromiumos/docs/+/HEAD/gsutil.md
   const result = await chrootService.exec(
-    'gsutil',
+    'gcloud',
     [
+      'storage',
       'ls',
       `gs://chromeos-image-archive/${board}-${imageType}/${versionPattern}/image.zip`,
     ],

--- a/src/test/unit/features/device_management/commands/check_image/suggest_image.test.ts
+++ b/src/test/unit/features/device_management/commands/check_image/suggest_image.test.ts
@@ -109,15 +109,16 @@ describe('Create quick pick to choose image within correct version range', () =>
     installChrootCommandHandler(
       fakeExec,
       tempDir.path,
-      'gsutil',
+      'gcloud',
       [
+        'storage',
         'ls',
         `gs://chromeos-image-archive/${BOARD_NAME}-release/*-${version}.*/image.zip`,
       ],
       async args => {
         return noMatch
           ? new AbnormalExitError(
-              'gsutil',
+              'gcloud',
               args,
               1,
               '',
@@ -138,7 +139,7 @@ describe('Create quick pick to choose image within correct version range', () =>
   });
 
   it('first shows current CrOS major version', async () => {
-    // Fake `gsutil ls` to fetch one match for release image with current CrOS major version 2.
+    // Fake `gcloud storage ls` to fetch one match for release image with current CrOS major version 2.
     handleFetchPrebuiltVersions(2, false);
 
     const option = showAllMatchingImagesQuickPick(
@@ -168,7 +169,7 @@ describe('Create quick pick to choose image within correct version range', () =>
   });
 
   it('expands to all images when user requests', async () => {
-    // Fake `gsutil ls` to fetch exactly one match for release image with CrOS major version 1 to 3.
+    // Fake `gcloud storage ls` to fetch exactly one match for release image with CrOS major version 1 to 3.
     handleFetchPrebuiltVersions(1, false);
     handleFetchPrebuiltVersions(2, false);
     handleFetchPrebuiltVersions(3, false);
@@ -211,7 +212,7 @@ describe('Create quick pick to choose image within correct version range', () =>
   });
 
   it('prompt to return to image type selection when there is no match', async () => {
-    // Fake `gsutil ls` to return no match for all versions.
+    // Fake `gcloud storage ls` to return no match for all versions.
     handleFetchPrebuiltVersions(1, true);
     handleFetchPrebuiltVersions(2, true);
     handleFetchPrebuiltVersions(3, true);

--- a/src/test/unit/features/device_management/prebuilt_util.test.ts
+++ b/src/test/unit/features/device_management/prebuilt_util.test.ts
@@ -27,8 +27,8 @@ gs://chromeos-image-archive/xyz-release/R99-9901.0.0/image.zip
     fakes.installChrootCommandHandler(
       fakeExec,
       tempDir.path,
-      'gsutil',
-      ['ls', 'gs://chromeos-image-archive/xyz-release/*/image.zip'],
+      'gcloud',
+      ['storage', 'ls', 'gs://chromeos-image-archive/xyz-release/*/image.zip'],
       () => FAKE_STDOUT
     );
 
@@ -61,8 +61,8 @@ gs://chromeos-image-archive/xyz-postsubmit/R102-10010.0.0-10100-1000000000000100
     fakes.installChrootCommandHandler(
       fakeExec,
       tempDir.path,
-      'gsutil',
-      ['ls', 'gs://chromeos-image-archive/xyz-postsubmit/*/image.zip'],
+      'gcloud',
+      ['storage', 'ls', 'gs://chromeos-image-archive/xyz-postsubmit/*/image.zip'],
       () => FAKE_STDOUT
     );
 
@@ -87,11 +87,11 @@ gs://chromeos-image-archive/xyz-postsubmit/R102-10010.0.0-10100-1000000000000100
     fakes.installChrootCommandHandler(
       fakeExec,
       tempDir.path,
-      'gsutil',
-      ['ls', 'gs://chromeos-image-archive/xyz-postsubmit/*/image.zip'],
+      'gcloud',
+      ['storage', 'ls', 'gs://chromeos-image-archive/xyz-postsubmit/*/image.zip'],
       async args =>
         new AbnormalExitError(
-          'gsutil',
+          'gcloud',
           args,
           1,
           '',


### PR DESCRIPTION
Automated: Migrate {target_path} from gsutil to gcloud storage

This CL is part of the on going effort to migrate from the legacy `gsutil` tool to the new and improved `gcloud storage` command-line interface.
`gcloud storage` is the recommended and modern tool for interacting with Google Cloud Storage, offering better performance, unified authentication, and a more consistent command structure with other `gcloud` components. 🚀

### Automation Details

This change was **generated automatically** by an agent that targets users of `gsutil`.
The transformations applied are based on the  [gsutil to gcloud storage migration guide](http://go/gsutil-gcloud-storage-migration-guide).

### ⚠️ Action Required: Please Review and Test Carefully

While we have based the automation on the migration guide, every use case is unique.
**It is crucial that you thoroughly test these changes in environments appropriate to your use-case before merging.**  
Be aware of potential differences between `gsutil` and `gcloud storage` that could impact your workflows.  
For instance, the structure of command output may have changed, requiring updates to any scripts that parse it. Similarly, command behavior can differ subtly; the `gcloud storage rsync` command has a different file deletion logic than `gsutil rsync`, which could lead to unintended file deletions.  

Our migration guides can help guide you through a list of mappings and some notable differences between the two tools.

Standard presubmit tests are run as part of this CL's workflow. **If you need to target an additional test workflow or require assistance with testing, please let us know.**

Please verify that all your Cloud Storage operations continue to work as expected to avoid any potential disruptions in production.

### Support and Collaboration

The `GCS CLI` team is here to help! If you encounter any issues, have a complex use case that this automated change doesn't cover, or face any other blockers, please don't hesitate to reach out.
We are happy to work with you to test and adjust these changes as needed.

**Contact:** `gcs-cli-hyd@google.com`

We appreciate your partnership in this important migration effort!

#gsutil-migration
